### PR TITLE
fix(build): Detect OS and set linker flags accordingly

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,17 +1,25 @@
 .PHONY : clean all
 .DEFAULT_GOAL := all
 
+UNAME := $(shell uname -m -s)
+OS = $(word 1, $(UNAME))
+
 CC=gcc
 FLAGS=-g -W -Wall
+LINK_FLAGS=-lpng
 TARGET=png2gba
- 
+
+ifeq ($(OS),Darwin)
+	LINK_FLAGS += -largp
+endif
+
 # do everything (default, for linux)
 all: $(TARGET)
 	@echo "All done!"
 
 # link it all together
 $(TARGET): png2gba.c
-	$(CC) $(FLAGS) -o $(TARGET) png2gba.c -lpng -largp
+	$(CC) $(FLAGS) -o $(TARGET) png2gba.c $(LINK_FLAGS)
 
 # tidy up
 clean:


### PR DESCRIPTION
Hi!

Sadly, PR #1 introduced a regression where building is no longer possible under linux as `-largp` is not known. This PR fixes this by adding an OS switch for this flag.

Before merging, please check if macOS still builds!

Note: this quick OS checks breaks building on Windows because of the `uname` dep.